### PR TITLE
PHRAS-3563 fix vfsstream name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   },
   "require-dev": {
     "empi89/php-amqp-stubs": "dev-master",
-    "mikey179/vfsStream": "^1.6",
+    "mikey179/vfsstream": "^1.6",
     "phpunit/phpunit": "^4.0|^5.0"
   },
   "suggest": {


### PR DESCRIPTION
## Changelog
  
### Fixes
  - #PHRAS-3563: fix vfsstream name

